### PR TITLE
made address input full width by modifying twitter-typeahead class to…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Added in navbar, restructured to remove fixed-width container, added aria landmark roles, did CSS styling
+
+###
+- Fixed twitter-typeahead to expand input to 100%

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -132,6 +132,11 @@ $bg-img: url('../public/assets/images/illustrated-city.jpg');
       border: 1px solid #fff;
     }
   }
+  .twitter-typeahead {
+    width: 100%;
+    display: table !important;
+    border-collapse: separate;
+  }
 }
 
 .list-group-item {


### PR DESCRIPTION
… use display table same as other 2 elements

Now looks like:
![screen shot 2017-02-10 at 10 38 51 am](https://cloud.githubusercontent.com/assets/7389593/22832888/ca9b9db0-ef7d-11e6-9dc2-df5d41116ef3.png)

Reasoning for the `!important` - the .input-group and .input-group-btn classes that Bootstrap provides to join the input and the button together in a snug pairing both use `display: table;border-collapse: separate;`. The .twitter-typeahead class changes the display to inline-block, but since this gets get inline, the only way to override it from the stylesheet is by way of an `!important`. If there was a way to change that style tag to `display: table` the `!important` in the app.scss could be removed. But basically all elements inside the .input-group need a `display: table`.

![screen shot 2017-02-10 at 10 40 20 am](https://cloud.githubusercontent.com/assets/7389593/22832881/c362221c-ef7d-11e6-8e29-948184ff76a1.png)


