### PR TITLE
remove ember data to save 30kb gzipped

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "ember-cli-surge": "1.1.16",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "^2.8.0",
     "ember-export-application-global": "^1.0.5",
     "ember-intl": "^2.15.1",
     "ember-load-initializers": "^0.5.1",


### PR DESCRIPTION
When running `ember build -e production`

Before:
vendor-157bfabb769db851f4d076db5e17f78e.js: 831.65 KB (215.91 KB gzipped)

After:
vendor-9831d78190db4b5a3dc7176abf12c80f.js: 695.44 KB (184.78 KB gzipped)

`ember s` works. I didn't try deploying to surge. Would suggest trying that before merging.
